### PR TITLE
Failing CodePipeline doesn't not send e-mail

### DIFF
--- a/labs/codepipeline/codepipeline-notifications.yml
+++ b/labs/codepipeline/codepipeline-notifications.yml
@@ -35,3 +35,16 @@ Resources:
       - Endpoint:
           Ref: EmailAddress
         Protocol: email
+  MySNSTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - Ref: MySNSTopic
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action:
+              - sns:Publish
+            Resource: "*"


### PR DESCRIPTION
# Change Details

Add policy allowing CloudWatch to publish messages to SNS. Without it an e-mail isn't sent to the specified e-mail address.

# Links

* [#16](https://github.com/stelligent/cloudformation_templates/issues/16)